### PR TITLE
Openengsb 318/eval repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -699,13 +699,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>apache-release</id>
-      <url>https://repository.apache.org/content/repositories/releases</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
       <id>jgit</id>
       <url>http://download.eclipse.org/jgit/maven</url>
       <snapshots>


### PR DESCRIPTION
maven-default-skin is still required by docs for some reason.
