### PR TITLE
Openengsb 595

### DIFF
--- a/core/workflow/src/main/resources/rulebase/imports
+++ b/core/workflow/src/main/resources/rulebase/imports
@@ -3,4 +3,5 @@ java.util.ArrayList
 java.util.Map
 java.util.HashMap
 org.openengsb.core.common.Event
+org.openengsb.core.common.workflow.model.Value
 org.openengsb.core.workflow.droolsinternal.DroolsFlowHelper


### PR DESCRIPTION
The Value class is meant to be used in rules and workflows to temporarily store data. Therefore it should absolutely be part of the default imports for the rulebase. Please also merge into integration.
