### PR TITLE
Openengsb 433

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,174 +1,246 @@
-=========================================================================
-==  NOTICE file for use with the Apache License, Version 2.0,          ==
-==  in this case for the Engineering Service Bus distribution.         ==
-=========================================================================
+Copyright 2010 OpenEngSB Division, Vienna University of Technology
 
-   
-   This product contains software developed by
-   The Engineering Service Bus Project (http://www.openengsb.org).
-   
-      Copyright (c) 2010 OpenEngSB Devision, Vienna University of Technology
-   
-=========================================================================
-==  Apache ServiceMix Notice                                           ==
-=========================================================================
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+  http://www.apache.org/licenses/LICENSE-2.0
 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-=========================================================================
-==  Bouncy Castle Notice                                               ==
-=========================================================================
-
-This product includes software (the ASN1 codec in the org.apache.geronimo.asn1
-package) which was developed by the Bouncy Castle project. 
-(http://www.bouncycastle.org/) 
-
-      Copyright (c) 2000-2005 The Legion Of The Bouncy Castle (http://www.bouncycastle.org)
-
-=========================================================================
-==  Spring Notice                                                      ==
-=========================================================================
-
-This product includes software developed by
-the Apache Software Foundation (http://www.apache.org).
-
-This product also includes software developed by
-Clinton Begin (http://www.ibatis.com).
-
-The end-user documentation included with a redistribution, if any,
-must include the following acknowledgement:
-
- "This product includes software developed by the Spring Framework
-  Project (http://www.springframework.org)."
-
-Alternately, this acknowledgement may appear in the software itself,
-if and wherever such third-party acknowledgements normally appear.
-
-The names "Spring" and "Spring Framework" must not be used to
-endorse or promote products derived from this software without
-prior written permission. For written permission, please contact
-rod.johnson@interface21.com or juergen.hoeller@interface21.com.
-  
-=========================================================================
-==  Xerces Notice                                                      ==
-=========================================================================
-
-Portions of this software were originally based on the following:
-  - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
-  - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
-  - voluntary contributions made by Paul Eng on behalf of the 
-    Apache Software Foundation that were originally developed at 
-    iClick, Inc., software copyright (c) 1999.
-
-
-=========================================================================
-==  XmlBeans Notice                                                    ==
-=========================================================================
-
-Portions of this software were originally based on the following:
-  - software copyright (c) 2000-2003, BEA Systems, <http://www.bea.com/>.
-
-Aside from contributions to the Apache XMLBeans project, this
-software also includes:
-
- - one or more source files from the Apache Xerces-J and Apache Axis
-   products, Copyright (c) 1999-2003 Apache Software Foundation
-
- - W3C XML Schema documents Copyright 2001-2003 (c) World Wide Web
-   Consortium (Massachusetts Institute of Technology, European Research
-   Consortium for Informatics and Mathematics, Keio University)
-
- - resolver.jar from Apache Xml Commons project,
-   Copyright (c) 2001-2003 Apache Software Foundation
-
- - Piccolo XML Parser for Java from http://piccolo.sourceforge.net/,
-   Copyright 2002 Yuval Oren under the terms of the Apache Software 
-   License 2.0
-
-=========================================================================
-==  Trac XML-RPC Notice                                                ==
-=========================================================================
-
-Copyright (c) 2005-2008, Alec Thomas (alec@swapoff.org)
-Copyright (c) 2009, CodeResort.com/BV Network AS
-(simon-code@bvnetwork.no)
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
- 1. Redistributions of source code must retain the above copyright notice,
-    this list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
- 3. Neither the name of the copyright holder(s) nor the names of its
-    contributors may be used to endorse or promote products derived from
-    this software without specific prior written permission.
-    
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-=========================================================================
-==  W3C Notice                                                         ==
-=========================================================================
-
-W3C® DOCUMENT LICENSE
-http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231
-
-Public documents on the W3C site are provided by the copyright holders under the following license. By using and/or copying this document, or the W3C document from which this statement is linked, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
-
-Permission to copy, and distribute the contents of this document, or the W3C document from which this statement is linked, in any medium for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the document, or portions thereof, that you use:
-
-   1. A link or URL to the original W3C document.
-   2. The pre-existing copyright notice of the original author, or if it doesn't exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright © [$date-of-document] World Wide Web Consortium, (Massachusetts Institute of Technology, European Research Consortium for Informatics and Mathematics, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231"
-   3. If it exists, the STATUS of the W3C document.
-
-When space permits, inclusion of the full text of this NOTICE should be provided. We request that authorship attribution be provided in any software, documents, or other items or products that you create pursuant to the implementation of the contents of this document, or any portion thereof.
-
-No right to create modifications or derivatives of W3C documents is granted pursuant to this license. However, if additional requirements (documented in the Copyright FAQ) are satisfied, the right to create modifications or derivatives is sometimes granted by the W3C to individuals complying with those requirements.
-
-THIS DOCUMENT IS PROVIDED "AS IS," AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
-
-COPYRIGHT HOLDERS WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
-
-The name and trademarks of copyright holders may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission. Title to copyright in this document will at all times remain with copyright holders.
-
-----------------------------------------------------------------------------
-
-This formulation of W3C's notice and license became active on December 31 2002. This version removes the copyright ownership notice such that this license can be used with materials other than those owned by the W3C, moves information on style sheets, DTDs, and schemas to the Copyright FAQ, reflects that ERCIM is now a host of the W3C, includes references to this specific dated version of the license, and removes the ambiguous grant of "use". See the older formulation for the policy prior to this date. Please see our Copyright FAQ for common questions about using materials from our site, such as the translating or annotating specifications. Other questions about this notice can be directed to site-policy@w3.org.
-
-Joseph Reagle <site-policy@w3.org>
-
-Last revised $Id: copyright-documents-20021231.html,v 1.6 2004/07/06 16:02:49 slesch Exp $
-
-=========================================================================
-==  NeoDatis Notice                                                    ==
-=========================================================================
-
- NeoDatis ODB : Native Object Database (odb.info@neodatis.org)
- Copyright (C) 2007 NeoDatis Inc. http://www.neodatis.org
-
- NeoDatis ODB is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation; either
- version 2.1 of the License, or (at your option) any later version.
-
- NeoDatis ODB is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
+This project includes:
+  ActiveIO :: Core under The Apache Software License, Version 2.0
+  ActiveMQ :: Core under The Apache Software License, Version 2.0
+  Antlr 3 Runtime under Apache License, Version 2.0
+  AOP alliance under Public Domain
+  Apache Aries Blueprint Bundle under The Apache Software License, Version 2.0
+  Apache Aries JMX Blueprint Bundle under The Apache Software License, Version 2.0
+  Apache Aries JMX Bundle under The Apache Software License, Version 2.0
+  Apache Aries Util under The Apache Software License, Version 2.0
+  Apache Felix Bundle Repository under The Apache Software License, Version 2.0
+  Apache Felix Configuration Admin Service under The Apache Software License, Version 2.0
+  Apache Felix File Install under The Apache Software License, Version 2.0
+  Apache Felix Framework under The Apache Software License, Version 2.0
+  Apache Felix Gogo Shell Runtime under The Apache Software License, Version 2.0
+  Apache Felix Main under The Apache Software License, Version 2.0
+  Apache Felix Metatype Service under The Apache Software License, Version 2.0
+  Apache Felix Shell Service under The Apache Software License, Version 2.0
+  Apache Felix Web Management Console under The Apache Software License, Version 2.0
+  Apache JAMES Mime4j under Apache License, Version 2.0
+  Apache Karaf :: Admin Command under The Apache Software License, Version 2.0
+  Apache Karaf :: Admin Core under The Apache Software License, Version 2.0
+  Apache Karaf :: Admin Management under The Apache Software License, Version 2.0
+  Apache Karaf :: Assembly under The Apache Software License, Version 2.0
+  Apache Karaf :: Blueprint Deployer under The Apache Software License, Version 2.0
+  Apache Karaf :: Client under The Apache Software License, Version 2.0
+  Apache Karaf :: Exception under The Apache Software License, Version 2.0
+  Apache Karaf :: Features Command under The Apache Software License, Version 2.0
+  Apache Karaf :: Features Core under The Apache Software License, Version 2.0
+  Apache Karaf :: Features Deployer under The Apache Software License, Version 2.0
+  Apache Karaf :: Features Management under The Apache Software License, Version 2.0
+  Apache Karaf :: Features OBR Resolver under The Apache Software License, Version 2.0
+  Apache Karaf :: JAAS Boot under The Apache Software License, Version 2.0
+  Apache Karaf :: JAAS Config under The Apache Software License, Version 2.0
+  Apache Karaf :: JAAS Modules under The Apache Software License, Version 2.0
+  Apache Karaf :: Main under The Apache Software License, Version 2.0
+  Apache Karaf :: Management under The Apache Software License, Version 2.0
+  Apache Karaf :: Manual under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell ConfigAdmin Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell Console under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell Development Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell Log Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell OBR Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell OSGi Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell PackageAdmin Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell SSH under The Apache Software License, Version 2.0
+  Apache Karaf :: Shell Various Commands under The Apache Software License, Version 2.0
+  Apache Karaf :: Spring Deployer under The Apache Software License, Version 2.0
+  Apache Karaf :: Testing environment under The Apache Software License, Version 2.0
+  Apache Karaf :: Util under The Apache Software License, Version 2.0
+  Apache Karaf :: WAR Deployer under The Apache Software License, Version 2.0
+  Apache Karaf :: Web Console :: Admin Plugin under The Apache Software License, Version 2.0
+  Apache Karaf :: Web Console :: Branding under The Apache Software License, Version 2.0
+  Apache Karaf :: Web Console :: Features Plugin under The Apache Software License, Version 2.0
+  Apache Karaf :: Web Console :: Gogo Plugin under The Apache Software License, Version 2.0
+  Apache MINA Core under Apache 2.0 License
+  Apache Mina SSHD :: Core under Apache 2.0 License
+  Apache ServiceMix :: Bundles :: junit under The Apache Software License, Version 2.0
+  Apache ServiceMix :: Bundles :: mail under The Apache Software License, Version 2.0
+  Apache WebServices Common Utilities under The Apache Software License, Version 2.0
+  Apache XML-RPC Client Library under The Apache Software License, Version 2.0
+  Apache XML-RPC Common Library under The Apache Software License, Version 2.0
+  AspectJ runtime under Eclipse Public License - v 1.0
+  AspectJ weaver under Eclipse Public License - v 1.0
+  avalon-framework under Apache License, Version 2.0
+  Backport of JSR 166 under Public Domain
+  Camel :: Core under The Apache Software License, Version 2.0
+  cglib under Apache License, Version 2.0
+  Codec under Apache License, Version 2.0
+  com.springsource.org.codehaus.janino under BSD license
+  Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Logging under The Apache Software License, Version 2.0
+  CSS Parser under GNU Lesser General Public License
+  Data Mapper for Jackson under The Apache Software License, Version 2.0
+  Discovery under The Apache Software License, Version 2.0
+  Drools :: API under The Apache Software License, Version 2.0
+  Drools :: Compiler under The Apache Software License, Version 2.0
+  Drools :: Core under The Apache Software License, Version 2.0
+  Eclipse ECJ under Eclipse Public License v1.0
+  geronimo-j2ee-management_1.0_spec under Apache License, Version 2.0
+  Guava (Google Common Libraries) under The Apache Software License, Version 2.0
+  Hamcrest All under BSD style
+  HtmlUnit under Apache License, Version 2.0
+  HtmlUnit Core JS under Mozilla Public License version 1.1
+  HttpClient under Apache License
+  HttpCore under Apache License
+  HttpMime under Apache License
+  Jackson under The Apache Software License, Version 2.0
+  jansi under The Apache Software License, Version 2.0
+  JCL 1.1.1 implemented over SLF4J under MIT License
+  JGit - Core under Eclipse Distribution License (New BSD License)
+  JLine under BSD
+  JMS 1.1 under The Apache Software License, Version 2.0
+  Joda time under Apache 2
+  JSch under BSD
+  JUnit under Common Public License Version 1.0
+  kXML 2 under The BSD License
+  Log4j under The Apache Software License, Version 2.0
+  Logging under The Apache Software License, Version 2.0
+  logkit under Apache License, Version 2.0
+  Mockito under The MIT License
+  mvel under Apache License, Version 2.0
+  Neko HTML under The Apache Software License, Version 2.0
+  NeoDatis Object Database under GNU Lesser General Public License
+  OpenEngSB :: Assembly under Apache 2
+  OpenEngSB :: Branding :: Parent under Apache 2
+  OpenEngSB :: Branding :: Shell under Apache 2
+  OpenEngSB :: Connector :: Email under Apache 2
+  OpenEngSB :: Connector :: Example under Apache 2
+  OpenEngSB :: Connector :: Git under Apache 2
+  OpenEngSB :: Connector :: Jira under Apache 2
+  OpenEngSB :: Connector :: Maven under Apache 2
+  OpenEngSB :: Connector :: MemoryAuditing under Apache 2
+  OpenEngSB :: Connector :: Parent under Apache 2
+  OpenEngSB :: Connector :: Plain Text Report under Apache 2
+  OpenEngSB :: Connector :: Trac under Apache 2
+  OpenEngSB :: Core :: Common under Apache 2
+  OpenEngSB :: Core :: Deployer :: Connector under Apache 2
+  OpenEngSB :: Core :: Deployer :: Parent under Apache 2
+  OpenEngSB :: Core :: Events under Apache 2
+  OpenEngSB :: Core :: Parent under Apache 2
+  OpenEngSB :: Core :: Persistence Layer under Apache 2
+  OpenEngSB :: Core :: Ports :: JMS under Apache 2
+  OpenEngSB :: Core :: Ports :: Parent under Apache 2
+  OpenEngSB :: Core :: Security under Apache 2
+  OpenEngSB :: Core :: Test under Apache 2
+  OpenEngSB :: Core :: Workflow Engine under Apache 2
+  OpenEngSB :: Documentation :: Examples under Apache 2
+  OpenEngSB :: Documentation :: Homepage under Apache 2
+  OpenEngSB :: Documentation :: Manual under Apache 2
+  OpenEngSB :: Documentation :: Parent under Apache 2
+  OpenEngSB :: Documentation :: Skin under Apache 2
+  OpenEngSB :: Domain :: Build under Apache 2
+  OpenEngSB :: Domain :: Deploy under Apache 2
+  OpenEngSB :: Domain :: Example under Apache 2
+  OpenEngSB :: Domain :: Issue under Apache 2
+  OpenEngSB :: Domain :: Notification under Apache 2
+  OpenEngSB :: Domain :: Parent under Apache 2
+  OpenEngSB :: Domain :: Report under Apache 2
+  OpenEngSB :: Domain :: Scm under Apache 2
+  OpenEngSB :: Domain :: Test under Apache 2
+  OpenEngSB :: Domains :: Auditing :: Implementation under Apache 2
+  OpenEngSB :: Integration Tests under Apache 2
+  OpenEngSB :: OSGi Wrapped Bundles :: HTML Unit Testing Framework under Apache 2
+  OpenEngSB :: Parent under Apache 2
+  OpenEngSB :: Plugin Configuration :: Compiled under Apache 2
+  OpenEngSB :: Plugin Configuration :: Parent under Apache 2
+  OpenEngSB :: Tooling :: Archetypes :: Connector under Apache 2
+  OpenEngSB :: Tooling :: Archetypes :: Domain under Apache 2
+  OpenEngSB :: Tooling :: Archetypes :: Parent under Apache 2
+  OpenEngSB :: Tooling :: Checkstyle under Apache 2
+  OpenEngSB :: Tooling :: Parent under Apache 2
+  OpenEngSB :: User Interface :: Administration under Apache 2
+  OpenEngSB :: User Interface :: Common under Apache 2
+  OpenEngSB :: User Interface :: Parent under Apache 2
+  OpenID4Java under Apache 2
+  OpenID4Java Consumer under Apache 2
+  OpenID4Java Consumer SampleConsumer under Apache 2
+  OpenID4Java no dependencies under Apache 2
+  OpenID4Java Server under Apache 2
+  OpenID4Java Server JdbcServerAssociationStore under Apache 2
+  OpenID4Java Server SampleServer under Apache 2
+  OPS4J Base - IO under ALv2
+  OPS4J Base - Lang under ALv2
+  OPS4J Base - Monitors under ALv2
+  OPS4J Base - Net under ALv2
+  OPS4J Base - Store under ALv2
+  OPS4J Pax Exam - API under Apache License, Version 2.0
+  OPS4J Pax Exam - Default Container (Pax Runner) under Apache License, Version 2.0
+  OPS4J Pax Exam - JUnit Extender API under Apache License, Version 2.0
+  OPS4J Pax Exam - JUnit Extender Implementation under Apache License, Version 2.0
+  OPS4J Pax Exam - JUnit Support under Apache License, Version 2.0
+  OPS4J Pax Exam - Remote Bundle Context under Apache License, Version 2.0
+  OPS4J Pax Exam - Remote Bundle Context Client under Apache License, Version 2.0
+  OPS4J Pax Exam - Runtime under Apache License, Version 2.0
+  OPS4J Pax Exam - SPI under Apache License, Version 2.0
+  OPS4J Pax Logging - API under ALv2
+  OPS4J Pax Logging - Service under ALv2
+  OPS4J Pax Runner - Core - No JCL under ALv2
+  OPS4J Pax Swissbox :: Extender under ALv2
+  OPS4J Pax Swissbox :: Lifecycle under ALv2
+  OPS4J Pax Swissbox :: Optional JCL under ALv2
+  OPS4J Pax Swissbox :: OSGi Core under ALv2
+  OPS4J Pax Url - mvn: under ALv2
+  OPS4J Pax Url - wrap: under ALv2
+  org.osgi.compendium under Apache License, Version 2.0
+  org.osgi.core under Apache License, Version 2.0
+  osgi under Apache License, Version 2.0
+  OSGi OBR Service API under The Apache Software License, Version 2.0
+  OSGi R4 Compendium Bundle under The Apache Software License, Version 2.0
+  OSGi R4 Core Bundle under The Apache Software License, Version 2.0
+  Servlet 2.5 under The Apache Software License, Version 2.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Simple API for CSS under The W3C Software License
+  SLF4J API Module under MIT License
+  SLF4J LOG4J-12 Binding under MIT License
+  SLF4J Simple Binding under MIT license
+  Spring OSGi Annotations under Apache License, Version 2.0
+  Spring OSGi Core under Apache License, Version 2.0
+  Spring OSGi Extender under Apache License, Version 2.0
+  Spring OSGi IO under Apache License, Version 2.0
+  Spring Security - Core under The Apache Software License, Version 2.0
+  Spring Security - Namespace Configuration Module under The Apache Software License, Version 2.0
+  Spring Security - OpenID support under The Apache Software License, Version 2.0
+  Spring Security - Web Application Security Module under The Apache Software License, Version 2.0
+  spring-aop under Apache License, Version 2.0
+  spring-asm under Apache License, Version 2.0
+  spring-beans under Apache License, Version 2.0
+  spring-context under Apache License, Version 2.0
+  spring-core under Apache License, Version 2.0
+  spring-expression under Apache License, Version 2.0
+  spring-jms under Apache License, Version 2.0
+  spring-tx under Apache License, Version 2.0
+  spring-web under Apache License, Version 2.0
+  Velocity under Apache License, Version 2.0
+  Wicket under The Apache Software License, Version 2.0
+  Wicket Auth Roles under The Apache Software License, Version 2.0
+  Wicket Date/Time under The Apache Software License, Version 2.0
+  Wicket Development Utilities under The Apache Software License, Version 2.0
+  Wicket Extensions under The Apache Software License, Version 2.0
+  Wicket IoC common code under The Apache Software License, Version 2.0
+  Wicket JMX under The Apache Software License, Version 2.0
+  Wicket Spring Integration under The Apache Software License, Version 2.0
+  Wicket Velocity under The Apache Software License, Version 2.0
+  Xalan Java under The Apache Software License, Version 2.0
+  Xalan Java Serializer under The Apache Software License, Version 2.0
+  Xerces2 Java Parser under The Apache Software License, Version 2.0
+  XML Commons External Components XML APIs under The Apache Software License, Version 2.0
+  XML Pull Parsing API under Public Domain
+  xml-apis under The Apache Software License, Version 2.0

--- a/etc/notice/NOTICE.template
+++ b/etc/notice/NOTICE.template
@@ -1,0 +1,16 @@
+Copyright 2010 OpenEngSB Division, Vienna University of Technology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This project includes:
+#GENERATED_NOTICES#

--- a/etc/notice/license-mapping.xml
+++ b/etc/notice/license-mapping.xml
@@ -1,0 +1,672 @@
+<?xml version="1.0" encoding="utf-8"?>
+<license-lookup xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd"
+>
+    <artifact>
+        <groupId>antisamy-bin</groupId>
+        <artifactId>org.owasp.validator</artifactId>
+        <license>BSD license</license>
+    </artifact>
+    <artifact>
+        <groupId>antlr</groupId>
+        <artifactId>antlr</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>asm</groupId>
+        <artifactId>asm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>asm</groupId>
+        <artifactId>asm-attrs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-css</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-ext</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-gui-util</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-util</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>castor</groupId>
+        <artifactId>castor</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib-full</artifactId>
+        <license>Apache License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>classworlds</groupId>
+        <artifactId>classworlds</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.google.code.googleportlet</groupId>
+        <artifactId>googleportlet</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.googlecode.cernunnos</groupId>
+        <artifactId>cernunnos</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-digester</groupId>
+        <artifactId>commons-digester</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>de.zeigermann.xml</groupId>
+        <artifactId>xml-im-exporter</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>dom4j</groupId>
+        <artifactId>dom4j</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>doxia</groupId>
+        <artifactId>doxia-sink-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>httpunit</groupId>
+        <artifactId>httpunit</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>ical4j</groupId>
+        <artifactId>ical4j</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>jakarta-regexp</groupId>
+        <artifactId>jakarta-regexp</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <license>Mozilla Public License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+        <name>JavaBeans(TM) Activation Framework</name>
+        <license>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.portlet</groupId>
+        <artifactId>portlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>groovy-engine</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>js-engine</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>script-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet</groupId>
+        <artifactId>jstl</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet.jsp</groupId>
+        <artifactId>jsp-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.transaction</groupId>
+        <artifactId>jta</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>jaxen</groupId>
+        <artifactId>jaxen</artifactId>
+        <license>Apache style license</license>
+    </artifact>
+    <artifact>
+        <groupId>jdom</groupId>
+        <artifactId>jdom</artifactId>
+        <license>Apache style license</license>
+    </artifact>
+    <artifact>
+        <groupId>junit-addons</groupId>
+        <artifactId>junit-addons</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>nekohtml</groupId>
+        <artifactId>nekohtml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <license>Creative Commons Attribution License</license>
+    </artifact>
+    <artifact>
+        <groupId>net.sf.jsr107cache</groupId>
+        <artifactId>jsr107cache</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>ognl</groupId>
+        <artifactId>ognl</artifactId>
+        <license>The OpenSymphony Software License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant-launcher</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.bcel</groupId>
+        <artifactId>bcel</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.commons.ssl</groupId>
+        <artifactId>not-yet-commons-ssl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-sink-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>resolver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>serializer</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>xml-apis</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-archiver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-container-default</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-digest</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-i18n</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-interactivity-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.cyberneko.html</groupId>
+        <artifactId>nekohtml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.hibernate</groupId>
+        <artifactId>ejb3-persistence</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>openws</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>xmltooling</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.osaf</groupId>
+        <artifactId>caldav4j</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.owasp</groupId>
+        <artifactId>antisamy</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-asm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aspects</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context-support</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jdbc</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-orm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-test</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-tx</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc-portlet</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ldap</groupId>
+        <artifactId>spring-ldap-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ldap</groupId>
+        <artifactId>spring-ldap-core-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.binding</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.js</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.webflow</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-binding</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-js</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-js-resources</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-webflow</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-oxm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-oxm-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-core-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-security</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-xml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>oro</groupId>
+        <artifactId>oro</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>portlet-api</groupId>
+        <artifactId>portlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>rhino</groupId>
+        <artifactId>js</artifactId>
+        <license>Mozilla Public License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>rome</groupId>
+        <artifactId>rome</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>slide</groupId>
+        <artifactId>jakarta-slide-webdavlib</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>taglibs</groupId>
+        <artifactId>standard</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>tyrex</groupId>
+        <artifactId>tyrex</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>velocity-tools</groupId>
+        <artifactId>velocity-tools</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xalan</groupId>
+        <artifactId>serializer</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xerces</groupId>
+        <artifactId>xmlParserAPIs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xml-apis</groupId>
+        <artifactId>xmlParserAPIs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xml-resolver</groupId>
+        <artifactId>xml-resolver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xom</groupId>
+        <artifactId>xom</artifactId>
+        <license>GNU Lesser General Public License</license>
+    </artifact>
+    <artifact>
+        <groupId>xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <license>BSD license</license>
+    </artifact>
+    <artifact>
+        <groupId>avalon-framework</groupId>
+        <artifactId>avalon-framework</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib-nodep</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>logkit</groupId>
+        <artifactId>logkit</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr-runtime</artifactId>    <!-- TODO: check license-->
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.geronimo.specs</groupId>
+        <artifactId>geronimo-j2ee-management_1.0_spec</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.janino</groupId>
+        <artifactId>com.springsource.org.codehaus.janino</artifactId>
+        <license>BSD license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.eclipse</groupId>
+        <artifactId>osgi</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.mvel</groupId>
+        <artifactId>mvel2</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.compendium</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <license>MIT license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jms</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>velocity</groupId>
+        <artifactId>velocity-dep</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+</license-lookup>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,17 @@
         <artifactId>features-maven-plugin</artifactId>
         <version>${karaf.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.jasig.maven</groupId>
+        <artifactId>maven-notice-plugin</artifactId>
+        <version>1.0.4</version>
+        <configuration>
+          <noticeTemplate>etc/notice/NOTICE.template</noticeTemplate>
+          <licenseMapping>
+            <param>etc/notice/license-mapping.xml</param>
+          </licenseMapping>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
added a plugin to autogenerate a notice file

mvn notice:check: verify for each dependency if its license is added to the NOTICE file 

etc/notice/NOTICE.template is the template for our license,

etc/notice/license-mapping.xml for each dependency we use has to be an entry which tells the plugin 
what the corresponding license is

mvn notice:generate : generates the file

kind regards philipp

//edit:
for one dependency i could not find the correct license: see license-mapping.xml line 623, i set it to apache license :
<artifact>
 <groupId>org.antlr</groupId>  
  <artifactId>antlr-runtime</artifactId>    <!-- TODO: check license-->
  <license>Apache License, Version 2.0</license>
</artifact>
