### PR TITLE
Openengsb 881/start events thrown too early fix

### DIFF
--- a/connector/maven/src/main/java/org/openengsb/connector/maven/internal/MavenServiceImpl.java
+++ b/connector/maven/src/main/java/org/openengsb/connector/maven/internal/MavenServiceImpl.java
@@ -111,8 +111,8 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
-                testEvents.raiseEvent(new TestStartEvent(id));
                 MavenResult result = excuteCommand(command);
+                testEvents.raiseEvent(new TestStartEvent(id));
                 if (result.isSuccess()) {
                     testEvents.raiseEvent(new TestSuccessEvent(id, result.getOutput()));
                 } else {
@@ -131,8 +131,8 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
-                testEvents.raiseEvent(new TestStartEvent(processId));
                 MavenResult result = excuteCommand(command);
+                testEvents.raiseEvent(new TestStartEvent(processId));
                 if (result.isSuccess()) {
                     testEvents.raiseEvent(new TestSuccessEvent(processId, result.getOutput()));
                 } else {
@@ -151,8 +151,8 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
-                buildEvents.raiseEvent(new BuildStartEvent(id));
                 MavenResult result = excuteCommand(command);
+                buildEvents.raiseEvent(new BuildStartEvent(id));
                 if (result.isSuccess()) {
                     buildEvents.raiseEvent(new BuildSuccessEvent(id, result.getOutput()));
                 } else {
@@ -171,10 +171,10 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
+                MavenResult result = excuteCommand(command);
                 BuildStartEvent buildStartEvent = new BuildStartEvent();
                 buildStartEvent.setProcessId(processId);
                 buildEvents.raiseEvent(buildStartEvent);
-                MavenResult result = excuteCommand(command);
                 if (result.isSuccess()) {
                     buildEvents.raiseEvent(new BuildSuccessEvent(processId, result.getOutput()));
                 } else {
@@ -203,8 +203,8 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
-                deployEvents.raiseEvent(new DeployStartEvent(id));
                 MavenResult result = excuteCommand(command);
+                deployEvents.raiseEvent(new DeployStartEvent(id));
                 if (result.isSuccess()) {
                     deployEvents.raiseEvent(new DeploySuccessEvent(id, result.getOutput()));
                 } else {
@@ -223,8 +223,8 @@ public class MavenServiceImpl extends AbstractOpenEngSBService implements MavenD
             @Override
             public void run() {
                 contextService.setThreadLocalContext(contextId);
-                deployEvents.raiseEvent(new DeployStartEvent(processId));
                 MavenResult result = excuteCommand(command);
+                deployEvents.raiseEvent(new DeployStartEvent(processId));
                 if (result.isSuccess()) {
                     deployEvents.raiseEvent(new DeploySuccessEvent(processId, result.getOutput()));
                 } else {

--- a/connector/maven/src/test/java/org/openengsb/connector/maven/internal/MavenServiceTest.java
+++ b/connector/maven/src/test/java/org/openengsb/connector/maven/internal/MavenServiceTest.java
@@ -28,7 +28,9 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.Date;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -207,11 +209,11 @@ public class MavenServiceTest {
         assertThat(event.getOutput(), containsString("SUCCESS"));
     }
 
-    @Ignore("OPENENGSB-881: buildStartEvent is raised too early")
     @Test
-    public void build_shouldCreateLogFileAndThrowItAway() throws Exception {
+    public void asyncBuild_shouldCreateLogFile() throws Exception {
         final Object syncFinish = new Object();
         final Object syncStart = new Object();
+        mavenService.setUseLogFile(true);
         mavenService.setSynchronous(false);
         mavenService.setProjectPath(getPath("test-unit-success"));
         mavenService.setCommand("clean compile");
@@ -221,11 +223,9 @@ public class MavenServiceTest {
         Thread waitForBuildEnd = startWaiterThread(syncFinish);
         mavenService.build();
         waitForBuildStart.join();
-        @SuppressWarnings("unchecked")
         Collection<File> listFiles = FileUtils.listFiles(new File("log"), FileFilterUtils.fileFileFilter(), null);
         assertThat("no logfile was created", listFiles.isEmpty(), is(false));
         waitForBuildEnd.join();
-        assertThat(listFiles.isEmpty(), is(true));
     }
 
     private void makeNotifyAnswerForBuildSuccess(final Object syncFinish) {


### PR DESCRIPTION
StartEvents are now raised in the runnable, right after the execution to assert delay-free execution.
