### PR TITLE
Openengsb-1106

### DIFF
--- a/core/common/src/main/java/org/openengsb/core/common/AbstractOpenEngSBInvocationHandler.java
+++ b/core/common/src/main/java/org/openengsb/core/common/AbstractOpenEngSBInvocationHandler.java
@@ -20,6 +20,9 @@ package org.openengsb.core.common;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
+
+import org.apache.commons.collections.CollectionUtils;
 
 /**
  * The OpenEngSB, and its projects can contain quite complex proxing of methods. This abstract class handles some of the
@@ -41,10 +44,12 @@ public abstract class AbstractOpenEngSBInvocationHandler implements InvocationHa
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if (handleObjectMethodsItself) {
             for (Method objectMethod : Object.class.getMethods()) {
-                if (objectMethod.getName().equals(method.getName())) {
+                if (objectMethod.getName().equals(method.getName()) &&
+                		Arrays.deepEquals(objectMethod.getParameterTypes(), method.getParameterTypes())) {
                     if (Proxy.isProxyClass(proxy.getClass())) {
                         if (Proxy.getInvocationHandler(proxy) instanceof AbstractOpenEngSBInvocationHandler) {
-                            return method.invoke(Proxy.getInvocationHandler(proxy), args);
+                            Object foo = method.invoke(Proxy.getInvocationHandler(proxy), args);
+                            return foo;
                         }
                     }
                 }


### PR DESCRIPTION
Hi, This patch fixes OPENENGSB-1106, the failure to invoke methods that share the name with methods in the base Object class.
