### PR TITLE
[OPENENGSB-1195] Connector archetype create ServiceManager with wrong constructor

### DIFF
--- a/tooling/archetypes/connector/src/main/resources/archetype-resources/src/main/java/__connectorName__ServiceManager.java
+++ b/tooling/archetypes/connector/src/main/resources/archetype-resources/src/main/java/__connectorName__ServiceManager.java
@@ -17,14 +17,14 @@
 
 package ${package};
 
-import org.openengsb.core.api.ServiceInstanceFactory;
 import org.openengsb.core.common.AbstractServiceManager;
 import ${domainPackage}.${domainInterface};
 import ${package}.internal.${connectorName}ServiceImpl;
+import ${package}.internal.${connectorName}ServiceInstanceFactory;
 
 public class ${connectorName}ServiceManager extends AbstractServiceManager<${domainInterface}, ${connectorName}ServiceImpl> {
 
-    public ${connectorName}ServiceManager(ServiceInstanceFactory<${domainInterface}, ${connectorName}ServiceImpl> factory) {
+    public ${connectorName}ServiceManager(${connectorName}ServiceInstanceFactory factory) {
         super(factory);
     }
 }


### PR DESCRIPTION
http://issues.openengsb.org/jira/browse/OPENENGSB-1195

changed that now the ServiceManager created by the archetype has the correct constructor parameter
