### PR TITLE
Openengsb 1284 - add global to the rulebase when a new connector(service) was created

### DIFF
--- a/ui/admin/src/main/java/org/openengsb/ui/admin/testClient/TestClient.java
+++ b/ui/admin/src/main/java/org/openengsb/ui/admin/testClient/TestClient.java
@@ -302,9 +302,9 @@ public class TestClient extends BasePage {
             ruleManager.addGlobal(jumpToService.getServiceClass(), jumpToService.getServiceId());
             ruleManager.addImport(jumpToService.getServiceClass());
         } catch (RuleBaseException e) {
-            LOGGER.debug("Unable to add global " + jumpToService.getServiceId() + " to the rulebase");
-            error("Unable to add global to the rulebase " + e.getLocalizedMessage());
-            // if the global already exists we can't show it on the website.
+            // in most cases we come here if we update a service, but there is no possibility I have
+            // found so far to tell the user easily that the global wasn't set.
+            LOGGER.debug("Unable to add global " + jumpToService.getServiceId() + " to the rulebase", e);
         }
 
         serviceList.getTreeState().collapseAll();


### PR DESCRIPTION
Only thing to notice here is that there is no possiblity to show the user that the inserting of the global failed. But with the changes of pull request https://github.com/openengsb/openengsb/pull/510 the user can manage this by himself if it wasn't added automatically.

I have set the FixVersion for this to openengsb-1.2.0.M6, but I think it's a rather small thing to merge.

http://issues.openengsb.org/jira/browse/OPENENGSB-1284
