### PR TITLE
[OPENENGSB-1477] maven copying docbook resources to homepage

### DIFF
--- a/docs/homepage/pom.xml
+++ b/docs/homepage/pom.xml
@@ -350,6 +350,22 @@
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <id>copy-manual-resources</id>
+            <phase>package</phase>
+            <configuration>
+              <target>
+                <copy todir="${basedir}/target/site/docbook">
+                  <fileset dir="${project.build.directory}/openengsb-docs-manual-${project.version}/manual/html-multi/">
+                    <exclude name="**/*.html" />
+                  </fileset>
+                </copy>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+          <execution>
             <phase>package</phase>
             <configuration>
               <target>


### PR DESCRIPTION
Signed-off-by: Alexander Pucher engsb@alexpucher.com

using ant-plugin to copy resources. Feels somewhat hacky, but seems to be the only suitable solution.
