### PR TITLE
[OPENENGSB-1597] set karaf.home, karaf.data and karaf.home in itests to a

### DIFF
--- a/itests/src/test/java/org/openengsb/itests/util/AbstractExamTestHelper.java
+++ b/itests/src/test/java/org/openengsb/itests/util/AbstractExamTestHelper.java
@@ -197,6 +197,8 @@ public abstract class AbstractExamTestHelper extends AbstractIntegrationTest {
         if (DEBUG) {
             baseOptions = combine(baseOptions, Helper.activateDebugging(Integer.toString(DEBUG_PORT)));
         }
+        String targetpath = new File("target").getAbsolutePath();
+        FileUtils.deleteDirectory(new File(targetpath, "karaf.data"));
         return combine(
             baseOptions,
             Helper.loadKarafStandardFeatures("config", "management"),
@@ -214,7 +216,11 @@ public abstract class AbstractExamTestHelper extends AbstractIntegrationTest {
             workingDirectory(getWorkingDirectory()),
             vmOption("-Dorg.osgi.framework.system.packages.extra=sun.reflect"),
             vmOption("-Dorg.osgi.service.http.port=" + WEBUI_PORT), waitForFrameworkStartup(),
+            vmOption("-Dkaraf.data=" + targetpath + "/karaf.data"),
+            vmOption("-Dkaraf.home=" + targetpath + "/karaf.home"),
+            vmOption("-Dkaraf.base=" + targetpath + "/karaf.base"),
             mavenBundle(maven().groupId("org.openengsb.wrapped").artifactId("net.sourceforge.htmlunit-all")
                 .versionAsInProject()), felix());
     }
+
 }


### PR DESCRIPTION
[OPENENGSB-1597] set karaf.home, karaf.data and karaf.home in itests to a path that FileInstaller uses.
