### PR TITLE
[OPENENGSB-3043] export javax.activation with version 1.1 to fix WSPortIT

### DIFF
--- a/assembly/src/main/filtered-resources/etc/jre.properties
+++ b/assembly/src/main/filtered-resources/etc/jre.properties
@@ -38,9 +38,13 @@
 # Java platform package export properties.
 #
 
+# NOTE: javax.activation has to be version="1.1" so that all bundles pick it up. CXF uses [0.0,2.0),
+# so all bundles need to acquire the package from the systembundle.
+
 # Standard package set.
 jre-1.6= \
  javax.accessibility, \
+ javax.activation;version="1.1", \
  javax.activity, \
  javax.annotation, \
  javax.annotation.processing, \
@@ -197,6 +201,7 @@ jre-1.6= \
 
 jre-1.7= \
  javax.accessibility, \
+ javax.activation;version="1.1", \
  javax.activity, \
  javax.annotation, \
  javax.annotation.processing, \


### PR DESCRIPTION
It seems a bit hacky. This fix forces the system-bundle to export the "javax.activation"-package with version "1.1" so that cxf imports this one instead of the package exported by the servicemix-activation-spec-bundle.
