### PR TITLE
[OPENENGSB-2406] fixed in AbstractDomainProvider

### DIFF
--- a/components/common/src/main/java/org/openengsb/core/common/AbstractDomainProvider.java
+++ b/components/common/src/main/java/org/openengsb/core/common/AbstractDomainProvider.java
@@ -100,9 +100,6 @@ public abstract class AbstractDomainProvider<DomainType extends Domain, DomainEv
     }
 
     private boolean isEventMethod(Method m) {
-        if (!m.getName().equals("raiseEvent")) {
-            return false;
-        }
         if (m.getParameterTypes().length == 0) {
             return false;
         }


### PR DESCRIPTION
removed the check which allowed only raiseEvent-methods with the name
"raiseEvent"
