### PR TITLE
[OPENENGSB-3241] refactored RequestHandlerImpl

### DIFF
--- a/components/services/src/main/java/org/openengsb/core/services/internal/RequestHandlerImpl.java
+++ b/components/services/src/main/java/org/openengsb/core/services/internal/RequestHandlerImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang.reflect.MethodUtils;
 import org.openengsb.core.api.OsgiUtilsService;
 import org.openengsb.core.api.context.ContextHolder;
@@ -185,7 +186,7 @@ public class RequestHandlerImpl implements RequestHandler {
         List<Class<?>> clazzes = new ArrayList<Class<?>>();
         for (String clazz : args.getClasses()) {
             try {
-                clazzes.add(this.getClass().getClassLoader().loadClass(clazz));
+                clazzes.add(ClassUtils.getClass(this.getClass().getClassLoader(), clazz));
             } catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException("The classes defined could not be found", e);
             }


### PR DESCRIPTION
Small Refactoring for the communication with the external XLink Client.
Builds without problems, but prePush fails due to JUnit Tests in JPA bundle

Failed tests:   testGetResurrectedOIDs_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): (..)
  testQueryWithTimestamp_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): (..)
  testQueryOfLastKnownVersion_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): (..)
  testCommitEDBObjectsUpdate_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): (..)
  testCommitEDBObjectsDelete_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): (..)
  testCommitEDBObjectsDeleteAlreadyDeleted_shouldThrowException(org.openengsb.core.edb.jpa.internal.JPATestIT): Expected exception: org.openengsb.core.edb.api.EDBException

Tests in error:
  testDiff_shouldWork(org.openengsb.core.edb.jpa.internal.JPATestIT): there are more than one commit for one timestamp

Errors possibly realted to my Win7 system, but are clealy not related to my refactoring.

kr Chris
