### PR TITLE
Openengsb-3254/v2.x.y version

### DIFF
--- a/components/common/src/main/java/org/openengsb/core/common/model/ModelProxyHandler.java
+++ b/components/common/src/main/java/org/openengsb/core/common/model/ModelProxyHandler.java
@@ -49,13 +49,7 @@ public class ModelProxyHandler extends AbstractOpenEngSBInvocationHandler {
         objects = new HashMap<String, OpenEngSBModelEntry>();
         fillModelWithNullValues(model);
         for (OpenEngSBModelEntry entry : entries) {
-            if (objects.containsKey(entry.getKey()) || entry.getKey().equals(EDBConstants.MODEL_OID)
-                    || entry.getKey().equals(EDBConstants.MODEL_VERSION)) {
-                objects.put(entry.getKey(), entry);
-            } else {
-                LOGGER.error("entry \"{}\" can not be set because the interface doesn't contain this field!",
-                    entry.getKey());
-            }
+            objects.put(entry.getKey(), entry);
         }
         initializeModelConverterSteps();
     }

--- a/components/edb/src/main/java/org/openengsb/core/edb/internal/JPADatabase.java
+++ b/components/edb/src/main/java/org/openengsb/core/edb/internal/JPADatabase.java
@@ -524,12 +524,12 @@ public class JPADatabase implements org.openengsb.core.api.edb.EngineeringDataba
         String oid = newObject.getOID();
         EDBObject object = getObject(oid);
         for (Map.Entry<String, Object> entry : newObject.entrySet()) {
-            if (entry.getKey().equals(EDBConstants.MODEL_VERSION)) {
+            if (entry.getKey().equals(EDBConstants.MODEL_VERSION) || entry.getKey().endsWith(".type")) {
                 continue;
             }
             Object value = object.get(entry.getKey());
             if (value == null || !value.equals(entry.getValue())) {
-                LOGGER.debug("Conflict detected at key %s when comparing %s with %s", new Object[]{ entry.getKey(),
+                LOGGER.error("Conflict detected at key {} when comparing {} with {}", new Object[]{ entry.getKey(),
                     entry.getValue(), value == null ? "null" : value.toString() });
                 throw new EDBException("Conflict detected. Failure when comparing the values of the key "
                         + entry.getKey());

--- a/components/ekb/src/main/java/org/openengsb/core/ekb/internal/EDBConverter.java
+++ b/components/ekb/src/main/java/org/openengsb/core/ekb/internal/EDBConverter.java
@@ -116,17 +116,38 @@ public class EDBConverter {
             return null;
         }
         Object instance = createNewInstance(model);
+        EDBObject workingCopy = new EDBObject(object);
 
         for (PropertyDescriptor propertyDescriptor : ModelUtils.getPropertyDescriptorsForClass(model)) {
             if (propertyDescriptor.getWriteMethod() == null) {
                 continue;
             }
             Method setterMethod = propertyDescriptor.getWriteMethod();
-            Object value = getValueForProperty(propertyDescriptor, object);
+            Object value = getValueForProperty(propertyDescriptor, workingCopy);
             if (value != null) {
                 invokeSetterMethod(setterMethod, instance, value);
             }
         }
+
+        for (Map.Entry<String, Object> entry : workingCopy.entrySet()) {
+            if (entry.getKey().endsWith(".type") || entry.getValue() == null) {
+                continue;
+            }
+            String type = workingCopy.getString(entry.getKey() + ".type");
+            Class<?> clazz = null;
+            if (type == null) {
+                clazz = entry.getValue().getClass();
+            } else {
+                try {
+                    clazz = model.getClassLoader().loadClass(type);
+                } catch (ClassNotFoundException e) {
+                    clazz = entry.getValue().getClass();
+                }
+            }
+            OpenEngSBModelEntry newEntry = new OpenEngSBModelEntry(entry.getKey(), entry.getValue(), clazz);
+            ((OpenEngSBModel) instance).addOpenEngSBModelEntry(newEntry);
+        }
+
         return instance;
     }
 
@@ -168,6 +189,8 @@ public class EDBConverter {
             return null;
         } else if (OpenEngSBModel.class.isAssignableFrom(parameterType)) {
             value = convertEDBObjectToUncheckedModel(parameterType, edbService.getObject((String) value));
+            object.remove(propertyName);
+            object.remove(propertyName + ".type");
         } else if (parameterType.equals(File.class)) {
             FileWrapper wrapper = new FileWrapper();
             String filename = (String) object.get(propertyName + ".filename");
@@ -175,12 +198,15 @@ public class EDBConverter {
             wrapper.setFilename(filename);
             wrapper.setContent(Base64.decodeBase64(content));
             value = FileConverterStep.getInstance().convertForGetter(wrapper);
+            object.remove(propertyName + ".filename");
+            object.remove(propertyName + ".type");
         } else if (object.containsKey(propertyName)) {
             if (parameterType.isEnum()) {
                 value = getEnumValue(parameterType, value);
             }
         }
 
+        object.remove(propertyName);
         return value;
     }
 
@@ -226,6 +252,8 @@ public class EDBConverter {
                 obj = convertEDBObjectToUncheckedModel(type, edbService.getObject(object.getString(property)));
             }
             temp.add(obj);
+            object.remove(property);
+            object.remove(property + ".type");
         }
         return temp;
     }
@@ -250,6 +278,10 @@ public class EDBConverter {
                 value = convertEDBObjectToUncheckedModel(valueType, edbService.getObject(value.toString()));
             }
             temp.put(key, value);
+            object.remove(keyProperty);
+            object.remove(keyProperty + ".type");
+            object.remove(valueProperty);
+            object.remove(valueProperty + ".type");
         }
         return temp;
     }
@@ -365,7 +397,7 @@ public class EDBConverter {
                 }
             } else {
                 object.put(entry.getKey(), entry.getValue());
-                object.put(entry.getKey() + ".value", entry.getValue());
+                object.put(entry.getKey() + ".type", entry.getValue().getClass().getName());
             }
         }
         Class<?> modelType = ModelUtils.getModelClassOfOpenEngSBModelObject(model.getClass());

--- a/components/ekb/src/test/java/org/openengsb/core/ekb/internal/EDBConverterTest.java
+++ b/components/ekb/src/test/java/org/openengsb/core/ekb/internal/EDBConverterTest.java
@@ -18,6 +18,7 @@
 package org.openengsb.core.ekb.internal;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -33,6 +34,8 @@ import org.openengsb.core.api.edb.EDBConstants;
 import org.openengsb.core.api.edb.EDBObject;
 import org.openengsb.core.api.edb.EngineeringDatabaseService;
 import org.openengsb.core.api.model.ConnectorId;
+import org.openengsb.core.api.model.OpenEngSBModel;
+import org.openengsb.core.api.model.OpenEngSBModelEntry;
 import org.openengsb.core.common.util.ModelUtils;
 import org.openengsb.core.ekb.internal.TestModel2.ENUM;
 
@@ -148,5 +151,29 @@ public class EDBConverterTest {
         assertThat(object.get("map0.value").toString(), is("valueA"));
         assertThat(object.get("map1.key").toString(), is("keyB"));
         assertThat(object.get("map1.value").toString(), is("valueB"));
+    }
+    
+    @Test
+    public void testEDBObjectToModelConversion_shouldWork() throws Exception {
+        EDBObject object = new EDBObject("test");
+        object.put(EDBConstants.MODEL_TYPE, TestModel.class.toString());
+        object.put(EDBConstants.MODEL_OID, "test");
+        object.put(EDBConstants.MODEL_VERSION, 1);
+        object.put("id", "test");
+        object.put("name", "testname");
+        
+        TestModel model = converter.convertEDBObjectToModel(TestModel.class, object);
+        assertThat(model.getId(), is("test"));
+        assertThat(model.getName(), is("testname"));
+        List<OpenEngSBModelEntry> entries = ((OpenEngSBModel) model).getOpenEngSBModelEntries();
+        Integer version = null;
+        for (OpenEngSBModelEntry entry : entries) {
+            if (entry.getKey().equals(EDBConstants.MODEL_VERSION)) {
+                version = (Integer) entry.getValue();
+                break;
+            }
+        }
+        assertThat(version, notNullValue());
+        assertThat(version, is(1));
     }
 }

--- a/itests/src/test/java/org/openengsb/itests/exam/EDBIT.java
+++ b/itests/src/test/java/org/openengsb/itests/exam/EDBIT.java
@@ -255,6 +255,27 @@ public class EDBIT extends AbstractExamTestHelper {
         EDBDeleteEvent event = new EDBDeleteEvent(model);
         edbService.processEDBDeleteEvent(event);
     }
+    
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testModelTailIsLoaded_shouldLoadModelTail() throws Exception {
+        TestModel model = ModelUtils.createEmptyModelObject(TestModel.class);
+        model.setName("blub");
+        model.setEdbId("modeltailtest/1");
+        EDBInsertEvent event = new EDBInsertEvent(model);
+        enrichEDBEvent(event);
+        edbService.processEDBInsertEvent(event);
+        
+        model = query.getModel(TestModel.class, "testdomain/testconnector/modeltailtest/1");
+        Boolean versionPresent = false;
+        for(OpenEngSBModelEntry entry : ((OpenEngSBModel) model).getOpenEngSBModelEntries()) {
+            if (entry.getKey().equals(EDBConstants.MODEL_VERSION)) {
+                versionPresent = true;
+            }
+        }
+        
+        assertThat(versionPresent, is(true));
+    }
 
     @Test
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This is the implementation of Openengsb-3254 for 2.x.y and 2.5.x. With it, the model tail will be added too when models are loaded through the QueryInterface. A version for the master branch will be provided soon

http://issues.openengsb.org/jira/browse/OPENENGSB-3254
