### PR TITLE
fix error that occurs when openengsb is shutdown

### DIFF
--- a/assembly/src/main/filtered-resources/features.xml
+++ b/assembly/src/main/filtered-resources/features.xml
@@ -148,7 +148,7 @@
     <bundle start-level='40'>mvn:org.openengsb.labs.delegation/org.openengsb.labs.delegation.service/${labs.delegation.version}</bundle>
     <!-- JPA Infrastructure -->
     <bundle start-level='20'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-dbcp/${servicemix.dbcp.version}</bundle>
-    <bundle start-level='30'>mvn:org.apache.openjpa/openjpa/${openjpa.version}</bundle>
+    <bundle start-level='25'>mvn:org.apache.openjpa/openjpa/${openjpa.version}</bundle>
     <bundle start-level='30'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.serp/${servicemix.serp.version}</bundle>
     <bundle start-level='30'>mvn:com.h2database/h2/${h2.version}</bundle>
     <bundle start-level='40'>mvn:org.openengsb.infrastructure/org.openengsb.infrastructure.jpa/${project.version}</bundle>


### PR DESCRIPTION
openjpa bundle must start before aries.jpa.container bundle, otherwise service unregistration occurs in wrong order. As a result, the registered persistence units will be unregistered twice -> error.
set start level of openjpa < start level of aries.jpa.container (30). 
