### PR TITLE
[OPENENGSB-3688] Added pax-wicket-blueprint to assembly features

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -228,6 +228,7 @@
                 <feature>spring-jms</feature>
                 <!-- Pax Wicket -->
                 <feature>pax-wicket</feature>
+                <feature>pax-wicket-blueprint</feature>
                 <feature>wicket</feature>
               </features>
               <copyFileBasedDescriptors>


### PR DESCRIPTION
Added pax-wicket-blueprint to assembly to fix error described in OPENENGSB-3688
