### PR TITLE
[OPENENGSB-3778] fix checkstyle errors in itests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_install:
   - mv repository ~/.m2/
   - rm oeb_bootstrap_m2_repo.zip
 
-install: mvn validate
+install: 
+  - mvn install -Pcheckstyle,licenseCheck
 
 script:
-  - mvn install -Pcheckstyle,licenseCheck
   - ./etc/scripts/run-itests.sh
 
 notifications:

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -159,7 +159,6 @@
       <groupId>org.openengsb.framework</groupId>
       <artifactId>org.openengsb.framework.api</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openengsb.framework.edb</groupId>
@@ -189,7 +188,6 @@
       <groupId>org.openengsb.framework.workflow</groupId>
       <artifactId>org.openengsb.framework.workflow.api</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openengsb.framework</groupId>
@@ -237,7 +235,6 @@
       <groupId>org.openengsb.domain</groupId>
       <artifactId>org.openengsb.domain.authentication</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.openengsb.domain</groupId>
@@ -334,7 +331,6 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-verifier</artifactId>
       <version>1.3</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/itests/src/test/java/org/openengsb/itests/htmlunit/TaskboxUiIT.java
+++ b/itests/src/test/java/org/openengsb/itests/htmlunit/TaskboxUiIT.java
@@ -49,7 +49,6 @@ import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 import org.osgi.framework.Constants;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
@@ -249,7 +248,7 @@ public class TaskboxUiIT extends AbstractPreConfiguredExamTestHelper {
         }
     }
 
-    private void loginAsAdmin() throws FailingHttpStatusCodeException, IOException {
+    private void loginAsAdmin() throws IOException {
         HtmlPage page = webClient.getPage(pageEntryUrl);
         HtmlForm form = page.getForms().get(0);
         HtmlSubmitInput loginButton = form.getInputByValue("Login");

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.openengsb</groupId>
     <artifactId>openengsb-root</artifactId>
-    <version>35</version>
+    <version>36-SNAPSHOT</version>
   </parent>
 
   <groupId>org.openengsb.framework</groupId>
@@ -47,26 +47,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
-  <properties>
-    <!-- base settings -->
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- maven plugin versions 
-    <maven.plugin.wagon.ssh.version>1.0-beta-6</maven.plugin.wagon.ssh.version>
-    <maven.plugin.wagon.webdav.version>1.0-beta-2</maven.plugin.wagon.webdav.version>-->
-    <root.version>35</root.version>   
-    <orientdb.version>1.2.0</orientdb.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.openengsb</groupId>
-        <artifactId>openengsb-root</artifactId>
-        <version>${root.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <modules>
     <!-- OpenEngSB API Modules -->


### PR DESCRIPTION
http://issues.openengsb.org/jira/browse/OPENENGSB-3778
some checkstyle rules/modules like RedundantThrows need to have the exception classes on the classpath.
