### PR TITLE
[OPENENGSB-3840] Much less should be logged in case of a JIRA userprojects sync failure

### DIFF
--- a/connector/userprojectsjira/src/main/java/org/openengsb/connector/userprojects/jira/internal/UserProjectsJiraServiceInstanceFactory.java
+++ b/connector/userprojectsjira/src/main/java/org/openengsb/connector/userprojects/jira/internal/UserProjectsJiraServiceInstanceFactory.java
@@ -83,7 +83,8 @@ public class UserProjectsJiraServiceInstanceFactory extends
                     JiraClient jiraClient = JiraClientFactory.create();
                     synchronizationService.syncFromJiraServerToOpenEngSB(jiraClient);
                 } catch (Exception e) {
-                    LOG.error("Could not sync from JIRA server to OpenEngSB", e);
+                    LOG.error("Could not sync from JIRA server to OpenEngSB. The configuration might be wrong.");
+                    LOG.debug("Sync error", e);
                 }
                 ContextHolder.get().setCurrentContextId(oldContext);
             }


### PR DESCRIPTION
In case of a failure only a short message is logged. The whole stacktrace is logged only in debug mode. The timer is not cancelled, since the failure might be a temporary one that does not occur due to misconfiguration.
